### PR TITLE
Fix headers formatting

### DIFF
--- a/AHKhttp.ahk
+++ b/AHKhttp.ahk
@@ -228,11 +228,11 @@ class HttpResponse
         FormatTime, date,, ddd, d MMM yyyy HH:mm:ss
         this.headers["Date"] := date
 
-        headers := this.protocol . " " . this.status . "`n"
+        headers := this.protocol . " " . this.status . "`r`n"
         for key, value in this.headers {
-            headers := headers . key . ": " . value . "`n"
+            headers := headers . key . ": " . value . "`r`n"
         }
-        headers := headers . "`n"
+        headers := headers . "`r`n"
         length := this.headers["Content-Length"]
 
         buffer := new Buffer((StrLen(headers) * 2) + length)


### PR DESCRIPTION
Currently Fiddler throws errors:
The Server did not return properly formatted HTTP Headers. HTTP headers
should be terminated with CRLFCRLF. These were terminated with LFLF.
