### PR TITLE
fix bug: 1.linefeed check; 2.param set error[res->respones]

### DIFF
--- a/AHKhttp.ahk
+++ b/AHKhttp.ahk
@@ -32,7 +32,7 @@ class HttpServer
             return false
 
         FileRead, data, % file
-        types := StrSplit(data, "`n")
+        types := StrSplit(data, "`r`n")
         this.mimes := {}
         for i, data in types {
             info := StrSplit(data, " ")
@@ -65,7 +65,7 @@ class HttpServer
         f.Close()
 
         response.SetBody(data, length)
-        res.headers["Content-Type"] := this.GetMimeType(file)
+        response.headers["Content-Type"] := this.GetMimeType(file)
     }
 
     SetPaths(paths) {


### PR DESCRIPTION
1. in windows, the text file linefeed usually `r`n
2. variable should be "response"